### PR TITLE
Add NVM prompt segment

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -492,6 +492,17 @@ prompt_node_version() {
   $1_prompt_segment "$0" "green" "white" "${nvm_prompt:1} $NODE_ICON"
 }
 
+# Node version from NVM
+# Only prints the segment if different than the default value
+prompt_nvm() {
+  local node_version=$(nvm current)
+  local nvm_default=$(cat $NVM_DIR/alias/default)
+  [[ -z "${node_version}" ]] && return
+  [[ "$node_version" =~ "$nvm_default" ]] && return
+  NODE_ICON=$'\u2B22' # ⬢
+  $1_prompt_segment "$0" "green" "011" "${node_version:1} $NODE_ICON"
+}
+
 # rbenv information
 prompt_rbenv() {
   if [[ -n "$RBENV_VERSION" ]]; then


### PR DESCRIPTION
Prints out the Node version that is currently active if it is different than the default version specified by NVM
